### PR TITLE
Add Material-based new design pages and update login flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS
+
+This repository contains an Angular application "PTI App" for tracking time investment across domains using Firebase/Firestore and Google authentication. Components include login, dashboard, domain management, activities, and activity reports. Services manage domains, targets/tasks, activities, and local storage. The app uses Angular's standalone component architecture and Chart.js for visualisations.
+
+## UI development guidelines
+- Existing pages are basic; redesigned pages live alongside them using Angular Material.
+- When creating redesigned pages, prefix component and route names with `new-`.
+- Keep Firestore structure and authentication services unchanged; new components should reuse existing services.
+- Run `npm test` and `npm run build` before committing.
+- The login flow stays unchanged; provide links to Material redesigns (e.g., `new-dashboard`) from authenticated pages like the existing dashboard.

--- a/pti-app/src/app/app.routes.ts
+++ b/pti-app/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { LoginComponent } from './components/login/login.component';
 import { DashboardComponent } from './components/dashboard/dashboard.component';
+import { NewDashboardComponent } from './components/new-dashboard/new-dashboard.component';
 import { ManageDomainsComponent } from './components/domains/manage-domains/manage-domains.component';
 import { ManageTargetsTasksComponent } from './components/domains/manage-targets-tasks/manage-targets-tasks.component';
 import { ActivityComponent } from './components/activity/activity.component';
@@ -11,6 +12,11 @@ export const routes: Routes = [
     {
         path: 'dashboard',
         component: DashboardComponent,
+        canActivate: [AuthGuard],
+    },
+    {
+        path: 'new-dashboard',
+        component: NewDashboardComponent,
         canActivate: [AuthGuard],
     },
     {

--- a/pti-app/src/app/components/dashboard/dashboard.component.html
+++ b/pti-app/src/app/components/dashboard/dashboard.component.html
@@ -13,8 +13,9 @@
             </div>
             <br>
             <div>
-                <button mat-stroked-button (click)="goToManageDomains()">Add / Edit Domains</button> &nbsp;
-                <button mat-stroked-button (click)="goToActivties()">Add / Edit Activity</button>
+                <button mat-stroked-button (click)="goToManageDomains()">Add / Edit Domains</button>&nbsp;
+                <button mat-stroked-button (click)="goToActivties()">Add / Edit Activity</button>&nbsp;
+                <button mat-stroked-button (click)="goToNewDashboard()">New Dashboard</button>
             </div>
         </div>
 

--- a/pti-app/src/app/components/new-dashboard/new-dashboard.component.html
+++ b/pti-app/src/app/components/new-dashboard/new-dashboard.component.html
@@ -1,0 +1,55 @@
+<mat-toolbar color="primary">
+  <span>PTI Dashboard</span>
+  <span class="spacer"></span>
+  <button mat-button (click)="logout()">Logout</button>
+</mat-toolbar>
+
+<div class="new-dashboard-container">
+  <mat-card class="welcome-card">
+    <h2>Welcome, {{ user?.displayName }}</h2>
+    <button mat-stroked-button (click)="goToManageDomains()">Add / Edit Domains</button>
+    <button mat-stroked-button (click)="goToActivties()">Add / Edit Activity</button>
+  </mat-card>
+
+  <mat-card>
+    <h3>Your Activity</h3>
+    <div class="chart-container">
+      <canvas baseChart [data]="polarChartData" [type]="'polarArea'" [options]="polarChartOptions"></canvas>
+    </div>
+  </mat-card>
+
+  <mat-card>
+    <h3>Time invested
+      <button mat-icon-button (click)="refreshData()"><mat-icon>refresh</mat-icon></button>
+    </h3>
+    <div class="period-wise-summary">
+      <div class="donut-chart-container">
+        <span>Today</span>
+        <canvas baseChart [data]="donutChartDataToday" [type]="'doughnut'" [options]="chartOptions" [plugins]="chartPlugins"></canvas>
+      </div>
+      <div class="donut-chart-container">
+        <span>Yesterday</span>
+        <canvas baseChart [data]="donutChartDataLast1Day" [type]="'doughnut'" [options]="chartOptions" [plugins]="chartPlugins"></canvas>
+      </div>
+      <div class="donut-chart-container">
+        <span>< 7 Days</span>
+        <canvas baseChart [data]="donutChartDataLast7Days" [type]="'doughnut'" [options]="chartOptions" [plugins]="chartPlugins"></canvas>
+      </div>
+      <div class="donut-chart-container">
+        <span>< 30 Days</span>
+        <canvas baseChart [data]="donutChartDataLast1Month" [type]="'doughnut'" [options]="chartOptions" [plugins]="chartPlugins"></canvas>
+      </div>
+    </div>
+  </mat-card>
+
+  <mat-card>
+    <h3>Your Domains</h3>
+    <mat-list>
+      <mat-list-item *ngFor="let domain of domains" (click)="goToDomain(domain)">
+        {{ domain.name }} - {{ domain.progress }}%
+      </mat-list-item>
+    </mat-list>
+  </mat-card>
+
+  <app-activity-report></app-activity-report>
+</div>

--- a/pti-app/src/app/components/new-dashboard/new-dashboard.component.scss
+++ b/pti-app/src/app/components/new-dashboard/new-dashboard.component.scss
@@ -1,0 +1,26 @@
+.spacer {
+  flex: 1 1 auto;
+}
+
+.new-dashboard-container {
+  padding: 16px;
+}
+
+mat-card {
+  margin-bottom: 16px;
+}
+
+.period-wise-summary {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+}
+
+.donut-chart-container {
+  text-align: center;
+  padding: 8px;
+}
+
+mat-list-item {
+  cursor: pointer;
+}

--- a/pti-app/src/app/components/new-dashboard/new-dashboard.component.ts
+++ b/pti-app/src/app/components/new-dashboard/new-dashboard.component.ts
@@ -14,6 +14,9 @@ import { LocalStorageService } from '../../services/local-storage.service';
 import { Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatCardModule } from '@angular/material/card';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatListModule } from '@angular/material/list';
 import { ActivityReportComponent } from '../activity-report/activity-report.component';
 
 Chart.register(...registerables);
@@ -26,13 +29,22 @@ interface Domain {
 }
 
 @Component({
-    selector: 'app-dashboard',
+    selector: 'app-new-dashboard',
     standalone: true,
-    imports: [CommonModule, BaseChartDirective, MatButtonModule, MatIconModule, ActivityReportComponent],
-    templateUrl: './dashboard.component.html',
-    styleUrls: ['./dashboard.component.scss'],
+    imports: [
+        CommonModule,
+        BaseChartDirective,
+        MatButtonModule,
+        MatIconModule,
+        MatCardModule,
+        MatToolbarModule,
+        MatListModule,
+        ActivityReportComponent,
+    ],
+    templateUrl: './new-dashboard.component.html',
+    styleUrls: ['./new-dashboard.component.scss'],
 })
-export class DashboardComponent implements OnInit {
+export class NewDashboardComponent implements OnInit {
     user: any;
     domains: Domain[] = [];
     polarChartLabels: string[] = [];
@@ -248,10 +260,6 @@ export class DashboardComponent implements OnInit {
 
     goToActivties() {
         this.router.navigate(['/activities']);
-    }
-
-    goToNewDashboard() {
-        this.router.navigate(['/new-dashboard']);
     }
 
     goToDomain(domain: { id: string; name: string }) {

--- a/pti-app/src/app/guards/auth.guard.spec.ts
+++ b/pti-app/src/app/guards/auth.guard.spec.ts
@@ -1,17 +1,28 @@
 import { TestBed } from '@angular/core/testing';
-import { CanActivateFn } from '@angular/router';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
 
-import { authGuard } from './auth.guard';
+import { AuthGuard } from './auth.guard';
+import { AuthService } from '../services/auth.service';
 
-describe('authGuard', () => {
-  const executeGuard: CanActivateFn = (...guardParameters) => 
-      TestBed.runInInjectionContext(() => authGuard(...guardParameters));
+describe('AuthGuard', () => {
+  let guard: AuthGuard;
+  const routerSpy = { navigate: jasmine.createSpy('navigate') } as any;
+  const authServiceStub = { getUser: () => of(null) };
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [
+        AuthGuard,
+        { provide: Router, useValue: routerSpy },
+        { provide: AuthService, useValue: authServiceStub }
+      ]
+    });
+
+    guard = TestBed.inject(AuthGuard);
   });
 
   it('should be created', () => {
-    expect(executeGuard).toBeTruthy();
+    expect(guard).toBeTruthy();
   });
 });

--- a/pti-app/src/app/services/auth.service.ts
+++ b/pti-app/src/app/services/auth.service.ts
@@ -96,7 +96,7 @@ export class AuthService {
     }
 
     // ✅ Sign in with Google Popup
-    async signInWithGoogle(): Promise<void> {
+    async signInWithGoogle(redirectRoute: string = '/dashboard'): Promise<void> {
         try {
             const provider = new GoogleAuthProvider();
             const credential = await signInWithPopup(this.auth, provider);
@@ -104,7 +104,7 @@ export class AuthService {
 
             await this.storeUserInFirestore(user);
             this.userSubject.next(user);
-            this.router.navigate(['/dashboard']);
+            this.router.navigate([redirectRoute]);
         } catch (error) {
             console.error('Login Error:', error);
         }


### PR DESCRIPTION
## Summary
- document project structure and UI guidelines in AGENTS.md
- add optional redirect to AuthService and "New Design" entry from dashboard
- build Material new-dashboard page alongside existing UI

## Testing
- `ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c5638d538832e9a01bac48c903ca9